### PR TITLE
Add -fsigned-char to 482.sphinx3 compatibility flags.

### DIFF
--- a/config/linux-arm64-gcc.cfg
+++ b/config/linux-arm64-gcc.cfg
@@ -77,6 +77,9 @@ EXTRA_CFLAGS   = -ansi
 PORTABILITY    = -DSPEC_CPU_LINUX -DSPEC_CPU_CASE_FLAG -DSPEC_CPU_LOGICAL_STRICT
 wrf_data_header_size = 8
 
+482.sphinx3=default=default=default:
+PORTABILITY    = -fsigned-char
+
 483.xalancbmk=default=default=default:
 CXXPORTABILITY = -DSPEC_CPU_LINUX
 


### PR DESCRIPTION
See: https://www.spec.org/cpu2006/Docs/faq.html#Miscompare.08.

482.sphinx3 will fail with a miscompare on some aarch64
toolchains if the -fsigned-char flag isn't passed around.
Note: (this is also true for 464.h264ref), but the arm64
config file already has that.